### PR TITLE
Potential fix for code scanning alert no. 5: Clear-text logging of sensitive information

### DIFF
--- a/internal/cmd/pull_cmd.go
+++ b/internal/cmd/pull_cmd.go
@@ -164,7 +164,7 @@ func runPullCommand(cmd *cobra.Command, args []string) {
 		}
 		
 		if err != nil {
-			fmt.Printf("Error decrypting content: %s\n", err)
+			fmt.Println("Error decrypting content. Please check the encryption key or password and try again.")
 			os.Exit(1)
 		}
 		

--- a/internal/encryption/encryption.go
+++ b/internal/encryption/encryption.go
@@ -107,7 +107,7 @@ func DecryptContent(content []byte) ([]byte, error) {
 	// Get the encryption key
 	key, err := getEncryptionKey()
 	if err != nil {
-		return nil, err
+		return nil, errors.New("failed to retrieve encryption key")
 	}
 	
 	// Create a new AES cipher block


### PR DESCRIPTION
Potential fix for [https://github.com/dexterity-inc/envi/security/code-scanning/5](https://github.com/dexterity-inc/envi/security/code-scanning/5)

To address the issue, we will sanitize the error message logged on line 167 in `internal/cmd/pull_cmd.go`. Instead of directly logging the error message, we will log a generic error message that does not include sensitive details. This ensures that sensitive information, such as the encryption password, is not exposed in the logs.

Additionally, we will review the `encryption.DecryptContent` function to ensure that it does not include sensitive data in its error messages. If necessary, we will modify the function to return sanitized error messages.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
