### PR TITLE
Potential fix for code scanning alert no. 4: Clear-text logging of sensitive information

### DIFF
--- a/internal/cmd/push_cmd.go
+++ b/internal/cmd/push_cmd.go
@@ -111,7 +111,7 @@ func runPushCommand(cmd *cobra.Command, args []string) {
 		fmt.Println("Masking values in .env file...")
 		maskedContent, err := encryption.MaskEnvContent(envContent)
 		if err != nil {
-			fmt.Printf("Error masking .env file: %s\n", err)
+			fmt.Println("Error masking .env file. Please check the input and try again.")
 			os.Exit(1)
 		}
 		envContent = maskedContent

--- a/internal/encryption/encryption.go
+++ b/internal/encryption/encryption.go
@@ -307,7 +307,7 @@ func getEncryptionKey() ([]byte, error) {
 		// Use TUI for password input
 		password, err = tui.GetPassword("Enter encryption password", false)
 		if err != nil {
-			return nil, err
+			return nil, errors.New("failed to retrieve encryption password")
 		}
 	} else {
 		// Use terminal input
@@ -331,7 +331,7 @@ func getEncryptionKey() ([]byte, error) {
 func getKeyFromFile() ([]byte, error) {
 	keyData, err := os.ReadFile(EncryptionKeyFile)
 	if err != nil {
-		return nil, fmt.Errorf("error reading key file: %w", err)
+		return nil, errors.New("failed to read encryption key file")
 	}
 	
 	// Clean the key data


### PR DESCRIPTION
Potential fix for [https://github.com/dexterity-inc/envi/security/code-scanning/4](https://github.com/dexterity-inc/envi/security/code-scanning/4)

To fix the issue, we need to ensure that sensitive information, such as the encryption password, is not logged in clear text. Instead of logging the raw error message, we can log a generic error message that does not include sensitive details. This approach ensures that sensitive data is not exposed while still providing useful debugging information.

The changes involve:
1. Replacing the logging of the raw `err` variable with a generic error message in `internal/cmd/push_cmd.go`.
2. Ensuring that error messages in `internal/encryption/encryption.go` do not include sensitive data.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
