### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/internal/cmd/share_cmd.go
+++ b/internal/cmd/share_cmd.go
@@ -69,7 +69,7 @@ func runShareCommand(cmd *cobra.Command, args []string) {
 	// Prepare environment content if needed
 	envContent, err := prepareEnvContent()
 	if err != nil {
-		fmt.Println("Error:", err)
+		fmt.Println("Error: An issue occurred while preparing the environment content. Please check the input and try again.")
 		os.Exit(1)
 	}
 	

--- a/internal/encryption/encryption.go
+++ b/internal/encryption/encryption.go
@@ -60,25 +60,25 @@ func EncryptContent(content []byte) ([]byte, error) {
 	// Get the encryption key
 	key, err := getEncryptionKey()
 	if err != nil {
-		return nil, err
+		return nil, errors.New("failed to retrieve encryption key")
 	}
 
 	// Create a new AES cipher block
 	block, err := aes.NewCipher(key)
 	if err != nil {
-		return nil, err
+		return nil, errors.New("failed to create AES cipher block")
 	}
 
 	// Create a new GCM
 	gcm, err := cipher.NewGCM(block)
 	if err != nil {
-		return nil, err
+		return nil, errors.New("failed to create GCM")
 	}
 
 	// Create a nonce
 	nonce := make([]byte, gcm.NonceSize())
 	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
-		return nil, err
+		return nil, errors.New("failed to generate nonce")
 	}
 
 	// Encrypt the data


### PR DESCRIPTION
Potential fix for [https://github.com/dexterity-inc/envi/security/code-scanning/2](https://github.com/dexterity-inc/envi/security/code-scanning/2)

To fix the issue, we need to ensure that sensitive information, such as the encryption password, is not logged in clear text. This can be achieved by sanitizing error messages before logging them or by avoiding logging errors that might contain sensitive data. Specifically:

1. In `internal/cmd/share_cmd.go`, replace the direct logging of the `err` variable on line 72 with a generic error message that does not include sensitive details.
2. In `internal/encryption/encryption.go`, ensure that any errors returned by the `EncryptContent` function and related methods do not include sensitive information.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
