### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/internal/cmd/merge_cmd.go
+++ b/internal/cmd/merge_cmd.go
@@ -137,7 +137,7 @@ func runMergeCommand(cmd *cobra.Command, args []string) {
 			}
 			
 			if err != nil {
-				fmt.Printf("Error decrypting content: %s\n", err)
+				fmt.Println("Error decrypting content. Please check your encryption settings and try again.")
 				os.Exit(1)
 			}
 			


### PR DESCRIPTION
Potential fix for [https://github.com/dexterity-inc/envi/security/code-scanning/1](https://github.com/dexterity-inc/envi/security/code-scanning/1)

To fix the issue, we need to ensure that sensitive information is not logged in clear text. Instead of logging the error message directly, we can log a generic error message that does not include sensitive details. This approach ensures that sensitive information, such as encryption passwords, is not exposed in logs.

Specifically:
1. Replace the `fmt.Printf` statement on line 140 of `internal/cmd/merge_cmd.go` with a generic error message that does not include the `err` variable.
2. Ensure that any sensitive information in the `err` variable is not inadvertently exposed elsewhere in the code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
