### PR TITLE
Add version and completion commands to Envi CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ envi pull --id GIST_ID
 - `envi share`: Share .env files with team members
 - `envi validate`: Validate .env file format and required variables
 - `envi merge`: Merge multiple .env files with conflict resolution
+- `envi version`: Display version information and build details
+- `envi completion`: Generate shell completion scripts for better CLI experience
 
 ## Advanced Usage
 
@@ -147,6 +149,26 @@ envi merge --files .env.defaults,.env.custom --overwrite
 # Output to a different file and sort variables
 envi merge --files .env.base,.env.test --output .env.combined --sort
 ```
+
+### Shell Completion
+
+Enable tab-completion for Envi commands in your terminal:
+
+```bash
+# Bash
+source <(envi completion bash)
+
+# Zsh
+source <(envi completion zsh)
+
+# Fish
+envi completion fish | source
+
+# PowerShell
+envi completion powershell | Out-String | Invoke-Expression
+```
+
+For permanent installation, see the help with `envi completion --help`.
 
 ## Package Distribution
 

--- a/internal/cmd/completion.go
+++ b/internal/cmd/completion.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var completionCmd = &cobra.Command{
+	Use:   "completion [bash|zsh|fish|powershell]",
+	Short: "Generate shell completion scripts",
+	Long: `Generate shell completion scripts for Envi CLI.
+To load completions:
+
+Bash:
+  $ source <(envi completion bash)
+
+  # To load completions for each session, execute once:
+  # Linux:
+  $ envi completion bash > /etc/bash_completion.d/envi
+  # macOS:
+  $ envi completion bash > $(brew --prefix)/etc/bash_completion.d/envi
+
+Zsh:
+  # If shell completion is not already enabled in your environment,
+  # you will need to enable it.  You can execute the following once:
+
+  $ echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+  # To load completions for each session, execute once:
+  $ envi completion zsh > "${fpath[1]}/_envi"
+
+Fish:
+  $ envi completion fish | source
+
+  # To load completions for each session, execute once:
+  $ envi completion fish > ~/.config/fish/completions/envi.fish
+
+PowerShell:
+  PS> envi completion powershell | Out-String | Invoke-Expression
+
+  # To load completions for every new session, run:
+  PS> envi completion powershell > envi.ps1
+  # and source this file from your PowerShell profile.
+`,
+	DisableFlagsInUseLine: true,
+	ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+	Args:                  cobra.ExactValidArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		switch args[0] {
+		case "bash":
+			cmd.Root().GenBashCompletion(os.Stdout)
+		case "zsh":
+			cmd.Root().GenZshCompletion(os.Stdout)
+		case "fish":
+			cmd.Root().GenFishCompletion(os.Stdout, true)
+		case "powershell":
+			cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
+		}
+	},
+}
+
+// InitCompletionCommand initializes the completion command
+func InitCompletionCommand() {
+	rootCmd.AddCommand(completionCmd)
+} 

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -32,6 +32,8 @@ func Execute() error {
 	InitListCommand()
 	InitValidateCommand()
 	InitMergeCommand()
+	InitVersionCommand()
+	InitCompletionCommand()
 	
 	// Initialize command flags
 	encryption.InitEncryptionFlags(rootCmd)

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/spf13/cobra"
+	"github.com/dexterity-inc/envi/internal/version"
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Display version information",
+	Long:  `Display the version number and build information for Envi CLI.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		displayVersion()
+	},
+}
+
+func displayVersion() {
+	fmt.Printf("Envi CLI v%s\n", version.GetVersion())
+	fmt.Printf("- Go version: %s\n", runtime.Version())
+	fmt.Printf("- OS/Arch: %s/%s\n", runtime.GOOS, runtime.GOARCH)
+}
+
+// InitVersionCommand initializes the version command
+func InitVersionCommand() {
+	rootCmd.AddCommand(versionCmd)
+} 


### PR DESCRIPTION
- Introduced `envi version` command to display version information and build details.
- Added `envi completion` command to generate shell completion scripts for Bash, Zsh, Fish, and PowerShell.
- Updated README.md to document new commands and provide usage examples.