### PR TITLE
Enhance build process to include versioning information

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,7 +16,7 @@ builds:
       - arm64
     main: ./cmd/envi
     ldflags:
-      - -s -w -X github.com/dexterity-inc/envi/internal/version.Version={{.Version}}
+      - -s -w -X github.com/dexterity-inc/envi/internal/version.Version={{.Version}} -X github.com/dexterity-inc/envi/internal/version.Commit={{.Commit}} -X github.com/dexterity-inc/envi/internal/version.BuildDate={{.Date}}
     binary: envi
 
 archives:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+.PHONY: build clean install dev
+
+# Get the current Git commit hash
+COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+# Get the current date in ISO 8601 format
+DATE := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+# Version from git tag or dev
+VERSION := $(shell git describe --tags 2>/dev/null || echo "dev")
+
+# Go build flags
+LDFLAGS := -s -w \
+	-X github.com/dexterity-inc/envi/internal/version.Version=$(VERSION) \
+	-X github.com/dexterity-inc/envi/internal/version.Commit=$(COMMIT) \
+	-X github.com/dexterity-inc/envi/internal/version.BuildDate=$(DATE)
+
+build:
+	go build -ldflags "$(LDFLAGS)" -o bin/envi ./cmd/envi
+
+dev:
+	go build -o bin/envi ./cmd/envi
+
+install: build
+	cp bin/envi $(GOPATH)/bin/envi
+
+clean:
+	rm -rf bin/ 

--- a/README.md
+++ b/README.md
@@ -283,7 +283,27 @@ Install-ChocolateyZipPackage $packageName $url64 $toolsDir -checksum64 $checksum
 ```bash
 git clone https://github.com/dexterity-inc/envi.git
 cd envi
+
+# Using Make (recommended - includes version information)
+make build
+
+# Or using Go directly
 go build -o envi ./cmd/envi
+```
+
+### Building with Version Information
+
+The `version` command displays the current version, build date, and commit hash. This information is set during the build process:
+
+```bash
+# For GoReleaser (automatic during release)
+goreleaser build --single-target --snapshot
+
+# For manual builds (using Make)
+make build
+
+# Verify the version information
+./bin/envi version
 ```
 
 ## License

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -19,6 +19,13 @@ var versionCmd = &cobra.Command{
 
 func displayVersion() {
 	fmt.Printf("Envi CLI v%s\n", version.GetVersion())
+	
+	// Only show commit and build date if not using the dev version
+	if version.GetVersion() != "dev" {
+		fmt.Printf("- Commit: %s\n", version.GetCommit())
+		fmt.Printf("- Build Date: %s\n", version.GetBuildDate())
+	}
+	
 	fmt.Printf("- Go version: %s\n", runtime.Version())
 	fmt.Printf("- OS/Arch: %s/%s\n", runtime.GOOS, runtime.GOARCH)
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -4,7 +4,25 @@ package version
 // This value is set by the build process using ldflags
 var Version = "dev"
 
+// Commit is the git commit SHA used to build the application
+// This value is set by the build process using ldflags
+var Commit = "unknown"
+
+// BuildDate is the date when the application was built
+// This value is set by the build process using ldflags
+var BuildDate = "unknown"
+
 // GetVersion returns the current version
 func GetVersion() string {
 	return Version
+}
+
+// GetCommit returns the git commit SHA
+func GetCommit() string {
+	return Commit
+}
+
+// GetBuildDate returns the build date
+func GetBuildDate() string {
+	return BuildDate
 } 


### PR DESCRIPTION
- Updated GoReleaser configuration to set commit hash and build date during the build.
- Introduced a Makefile for simplified builds with version information.
- Updated README.md to document the new build process and version display.
- Modified version command to conditionally show commit and build date based on version.