### PR TITLE
Update Go version, enhance Makefile for testing, and improve version …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build clean install dev
+.PHONY: build clean install dev test-version
 
 # Get the current Git commit hash
 COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
@@ -6,6 +6,8 @@ COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 DATE := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 # Version from git tag or dev
 VERSION := $(shell git describe --tags 2>/dev/null || echo "dev")
+# Test version for development
+TEST_VERSION ?= 1.0.15
 
 # Go build flags
 LDFLAGS := -s -w \
@@ -13,11 +15,25 @@ LDFLAGS := -s -w \
 	-X github.com/dexterity-inc/envi/internal/version.Commit=$(COMMIT) \
 	-X github.com/dexterity-inc/envi/internal/version.BuildDate=$(DATE)
 
+# Test version build flags
+TEST_LDFLAGS := -s -w \
+	-X github.com/dexterity-inc/envi/internal/version.Version=$(TEST_VERSION) \
+	-X github.com/dexterity-inc/envi/internal/version.Commit=$(COMMIT) \
+	-X github.com/dexterity-inc/envi/internal/version.BuildDate=$(DATE)
+
 build:
+	mkdir -p bin
 	go build -ldflags "$(LDFLAGS)" -o bin/envi ./cmd/envi
 
 dev:
+	mkdir -p bin
 	go build -o bin/envi ./cmd/envi
+
+test-version:
+	mkdir -p bin
+	go build -ldflags "$(TEST_LDFLAGS)" -o bin/envi ./cmd/envi
+	@echo "\nTesting version command with version $(TEST_VERSION):"
+	./bin/envi version
 
 install: build
 	cp bin/envi $(GOPATH)/bin/envi

--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ envi pull --id GIST_ID
 - `envi share`: Share .env files with team members
 - `envi validate`: Validate .env file format and required variables
 - `envi merge`: Merge multiple .env files with conflict resolution
-- `envi version`: Display version information and build details
 - `envi completion`: Generate shell completion scripts for better CLI experience
 
 ## Advanced Usage
@@ -148,6 +147,18 @@ envi merge --files .env.defaults,.env.custom --overwrite
 
 # Output to a different file and sort variables
 envi merge --files .env.base,.env.test --output .env.combined --sort
+```
+
+### Version Information
+
+To check the version of Envi CLI:
+
+```bash
+# Display version number
+envi --version
+
+# Or using the short flag
+envi -v
 ```
 
 ### Shell Completion

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,8 @@
 module github.com/dexterity-inc/envi
 
-go 1.21
-toolchain go1.24.1
+go 1.23.0
+
+toolchain go1.24.2
 
 require (
 	github.com/charmbracelet/bubbles v0.17.1

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -9,10 +9,21 @@ import (
 
 // Root command definition
 var rootCmd = &cobra.Command{
-	Use:   "envi",
-	Short: "Manage environment variables with GitHub Gists",
-	Long:  `Envi is a secure tool for storing and sharing .env files via GitHub Gists.`,
+	Use:     "envi",
+	Short:   "Manage environment variables with GitHub Gists",
+	Long:    `Envi is a secure tool for storing and sharing .env files via GitHub Gists.`,
 	Version: version.Version,
+	
+	// This will run before the main command execution
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		// Check if the version flag was used
+		if cmd.Flag("version") != nil && cmd.Flag("version").Changed {
+			displayVersion()
+			// Call os.Exit(0) to prevent the Run function from executing
+			cobra.CheckErr(nil)
+		}
+	},
+	
 	Run: func(cmd *cobra.Command, args []string) {
 		// Show help by default when no subcommand is provided
 		cmd.Help()

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -4,19 +4,10 @@ import (
 	"fmt"
 	"runtime"
 
-	"github.com/spf13/cobra"
 	"github.com/dexterity-inc/envi/internal/version"
 )
 
-var versionCmd = &cobra.Command{
-	Use:   "version",
-	Short: "Display version information",
-	Long:  `Display the version number and build information for Envi CLI.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		displayVersion()
-	},
-}
-
+// displayVersion prints the version information
 func displayVersion() {
 	fmt.Printf("Envi CLI v%s\n", version.GetVersion())
 	
@@ -30,7 +21,15 @@ func displayVersion() {
 	fmt.Printf("- OS/Arch: %s/%s\n", runtime.GOOS, runtime.GOARCH)
 }
 
-// InitVersionCommand initializes the version command
+// InitVersionCommand initializes the version flags
 func InitVersionCommand() {
-	rootCmd.AddCommand(versionCmd)
+	// We don't need a separate version command as Cobra already provides
+	// --version flag. This function is kept for consistency in command initialization.
+	
+	// Add a custom -v short flag for version
+	rootCmd.Flags().BoolP("version", "v", false, "Display version information")
+	
+	// Override the default version template to use our custom version display
+	rootCmd.SetVersionTemplate(`{{.Name}} version {{.Version}}
+`)
 } 

--- a/test-version.sh
+++ b/test-version.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Set a test version for development
+export TEST_VERSION="1.0.15"
+
+echo "Building Envi CLI with test version $TEST_VERSION..."
+go build -ldflags "-s -w \
+  -X github.com/dexterity-inc/envi/internal/version.Version=$TEST_VERSION \
+  -X github.com/dexterity-inc/envi/internal/version.Commit=$(git rev-parse --short HEAD) \
+  -X github.com/dexterity-inc/envi/internal/version.BuildDate=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+  -o ./bin/envi ./cmd/envi
+
+echo -e "\nTesting version short flag:"
+./bin/envi -v
+
+echo -e "\nTesting version long flag:"
+./bin/envi --version 


### PR DESCRIPTION
…display

- Changed Go version from 1.21 to 1.23.0 in go.mod.
- Updated Makefile to include a new `test-version` target for building with a test version.
- Added a script for testing version commands and updated README.md to document version checking.
- Modified root command to handle version flag and display version information directly.